### PR TITLE
Fixed Issue in gilab link tooltip

### DIFF
--- a/webapp/src/components/link_tooltip/tooltip.css
+++ b/webapp/src/components/link_tooltip/tooltip.css
@@ -73,6 +73,7 @@
     line-height: 1.25;
     overflow: hidden;
     font-size: 12px;
+    word-break: break-word;
 }
 
 .gitlab-tooltip .tooltip-info .markdown-text::-webkit-scrollbar {


### PR DESCRIPTION
Heading and description text overlays in tooltip when crosses a certain limit
Before-
![Screenshot from 2022-07-27 14-48-00](https://user-images.githubusercontent.com/55234496/181211228-b773340c-41ab-4339-9cfb-e087c1913e01.png)

Now-
![Screenshot from 2022-07-27 14-46-16](https://user-images.githubusercontent.com/55234496/181211212-fece63da-64a9-4cd4-9102-006796a31246.png)

**Ticket-**
https://brightscout.atlassian.net/browse/MI-1919?atlOrigin=eyJpIjoiYjU4ZmE3NDY2MmMwNGJkZmFlMGFkYTZhMDAyODNkZTgiLCJwIjoiaiJ9