### PR TITLE
[MI-1995] Fixed failing CI in link tooltip PR

### DIFF
--- a/webapp/src/components/link_tooltip/link_tooltip.jsx
+++ b/webapp/src/components/link_tooltip/link_tooltip.jsx
@@ -26,8 +26,9 @@ const LINK_TYPES = {
 export const LinkTooltip = ({href, connected}) => {
     const [data, setData] = useState(null);
     useEffect(() => {
+        const url = new URL(href);
         const init = async () => {
-            if (href.includes('gitlab.com/') && validateGitlabURL(href)) {
+            if (url.hostname === 'gitlab.com' && validateGitlabURL(href)) {
                 const [owner, repo, , type, number] = href.split('gitlab.com/')[1].split('/');
                 let res;
                 switch (type) {


### PR DESCRIPTION
1. Fixed the error "'gitlab.com' can be anywhere in the URL, and arbitrary hosts may come before or after it."
![Screenshot from 2022-07-28 15-36-01](https://user-images.githubusercontent.com/55234496/181480036-bb84f2dc-3b3a-4017-90fc-f5161648d384.png)

