### PR TITLE
[MI-2993] Review fixes on Gitlab PR #299(Show code block preview)

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -91,9 +91,24 @@
             },
             {
                 "key": "EnableCodePreview",
-                "display_name": "Enable Code Previews",
-                "type": "bool",
-                "help_text": "(Optional) Allow the plugin to expand permalinks to GitLab files with an actual preview of the linked file."
+                "display_name": "Enable Code Previews:",
+                "type": "dropdown",
+                "help_text": "Allow the plugin to expand permalinks to GitLab files with an actual preview of the linked file.",
+                "default": "public",
+                "options": [
+                    {
+                        "display_name": "Enable for public projects",
+                        "value": "public"
+                    },
+                    {
+                        "display_name": "Enable for public and private projects. This might leak confidential code into public channels",
+                        "value": "privateAndPublic"
+                    },
+                    {
+                        "display_name": "Disable",
+                        "value": "disable"
+                    }
+                ]
             }
         ]
     }

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -33,7 +33,7 @@ type configuration struct {
 	EncryptionKey               string `json:"encryptionkey"`
 	GitlabGroup                 string `json:"gitlabgroup"`
 	EnablePrivateRepo           bool   `json:"enableprivaterepo"`
-	EnableCodePreview           bool   `json:"enablecodepreview"`
+	EnableCodePreview           string `json:"enablecodepreview"`
 	UsePreregisteredApplication bool   `json:"usepreregisteredapplication"`
 }
 

--- a/server/permalinks.go
+++ b/server/permalinks.go
@@ -100,7 +100,7 @@ func (p *Plugin) processReplacement(r replacement, glClient *gitlab.Client, wg *
 	projectPath := fmt.Sprintf("%s/%s", r.permalinkData.user, r.permalinkData.repo)
 
 	// Check if project is public
-	if p.getConfiguration().EnableCodePreview != "privateAndPublic" {
+	if p.getConfiguration().EnableCodePreview == "public" {
 		repo, _, err := glClient.Projects.GetProject(projectPath, &gitlab.GetProjectOptions{})
 		if err != nil {
 			p.API.LogError("Error while fetching project information", "error", err.Error())

--- a/server/permalinks.go
+++ b/server/permalinks.go
@@ -99,7 +99,7 @@ func (p *Plugin) processReplacement(r replacement, glClient *gitlab.Client, wg *
 	}
 	projectPath := fmt.Sprintf("%s/%s", r.permalinkData.user, r.permalinkData.repo)
 
-	// Check if project is public
+	// Check if the project is public
 	if p.getConfiguration().EnableCodePreview == "public" {
 		repo, _, err := glClient.Projects.GetProject(projectPath, &gitlab.GetProjectOptions{})
 		if err != nil {

--- a/server/permalinks_test.go
+++ b/server/permalinks_test.go
@@ -242,6 +242,9 @@ func TestGetReplacements(t *testing.T) {
 
 func TestMakeReplacements(t *testing.T) {
 	p := NewPlugin()
+	p.configuration = &configuration{
+		EnableCodePreview: "privateAndPublic",
+	}
 	mockPluginAPI := &plugintest.API{}
 	mockPluginAPI.On("LogDebug", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	mockPluginAPI.On("LogWarn", mock.Anything, mock.Anything)

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -158,7 +158,7 @@ func (p *Plugin) OnPluginClusterEvent(c *plugin.Context, ev model.PluginClusterE
 
 func (p *Plugin) MessageWillBePosted(c *plugin.Context, post *model.Post) (*model.Post, string) {
 	// If not enabled in config, ignore.
-	if !p.getConfiguration().EnableCodePreview {
+	if p.getConfiguration().EnableCodePreview == "disable" {
 		return nil, ""
 	}
 


### PR DESCRIPTION
PR link: https://github.com/mattermost/mattermost-plugin-gitlab/pull/299

1. Added dropdown in config setting to specify the visisbilty of the projects whose preview we should display.