### PR TITLE
[MI-3567] Fix UX for member_access_request in right hand sidebar

### DIFF
--- a/webapp/src/components/sidebar_right/gitlab_items.tsx
+++ b/webapp/src/components/sidebar_right/gitlab_items.tsx
@@ -20,12 +20,13 @@ export const notificationReasons: Record<string | symbol, string> = {
     approval_required: 'Your approval is required on this issue/merge request.',
     unmergeable: 'This merge request can\'t be merged.',
     merge_train_removed: 'A merge train was removed.',
+    member_access_requested: 'reqested access to a project/group.'
 };
 
 const SUCCESS = 'success';
 const PENDING = 'pending';
 
-function GitlabItems({item, theme}: GitlabItemsProps) {
+function GitlabItems({item, theme}: GitlabItemsProps) {    
     const style = getStyle(theme);
 
     const repoName = item.references?.full || item.project?.path_with_namespace || '';
@@ -48,7 +49,7 @@ function GitlabItems({item, theme}: GitlabItemsProps) {
         );
     }
 
-    const titleText = item.title || item.target?.title || '';
+    const titleText = item.title || item.target?.title || item.body || '';
 
     let title: React.ReactNode = titleText;
     if (item.web_url || item.target_url) {
@@ -174,17 +175,14 @@ function GitlabItems({item, theme}: GitlabItemsProps) {
             </div>
             <div>
                 {number}
-                <span className='light'>{repoName}</span>
+                {repoName && <span className='light'>({repoName})</span>}
             </div>
             {labels}
             <div
                 className='light'
                 style={style.subtitle}
             >
-                {'Opened'}
                 {item.created_at && ` ${formatTimeSince(item.created_at)} ago`}
-                {userName && ` by ${userName}`}
-                {'.'}
                 {milestone}
             </div>
             <div
@@ -194,7 +192,7 @@ function GitlabItems({item, theme}: GitlabItemsProps) {
                 {item.action_name && (
                     <>
                         <div>{item.updated_at && `Updated ${formatTimeSince(item.updated_at)} ago.`}</div>
-                        {notificationReasons[item.action_name]}
+                        {item.action_name=='member_access_requested' && <a href={item.author.web_url}>{item.author.name}</a>} {notificationReasons[item.action_name]}
                     </>
                 )}
             </div>

--- a/webapp/src/components/sidebar_right/gitlab_items.tsx
+++ b/webapp/src/components/sidebar_right/gitlab_items.tsx
@@ -25,7 +25,7 @@ export const notificationReasons: Record<string | symbol, string> = {
 
 const SUCCESS = 'success';
 const PENDING = 'pending';
-const ActionNameMemberAccessRequested = 'member_access_requested';
+const ACTION_NAME_MEMBER_ACCESS_REQUESTED = 'member_access_requested';
 
 function GitlabItems({item, theme}: GitlabItemsProps) {
     const style = getStyle(theme);
@@ -193,7 +193,7 @@ function GitlabItems({item, theme}: GitlabItemsProps) {
                 {item.action_name && (
                     <>
                         <div>{item.updated_at && `Updated ${formatTimeSince(item.updated_at)} ago.`}</div>
-                        {item.action_name==ActionNameMemberAccessRequested && <a href={item.author.web_url}>{item.author.name}</a>} {notificationReasons[item.action_name]}
+                        {item.action_name == ACTION_NAME_MEMBER_ACCESS_REQUESTED && <a href={item.author.web_url}>{item.author.name}</a>} {notificationReasons[item.action_name]}
                     </>
                 )}
             </div>

--- a/webapp/src/components/sidebar_right/gitlab_items.tsx
+++ b/webapp/src/components/sidebar_right/gitlab_items.tsx
@@ -20,13 +20,14 @@ export const notificationReasons: Record<string | symbol, string> = {
     approval_required: 'Your approval is required on this issue/merge request.',
     unmergeable: 'This merge request can\'t be merged.',
     merge_train_removed: 'A merge train was removed.',
-    member_access_requested: 'reqested access to a project/group.'
+    member_access_requested: 'requested access to a project/group.'
 };
 
 const SUCCESS = 'success';
 const PENDING = 'pending';
+const ActionNameMemberAccessRequested = 'member_access_requested'
 
-function GitlabItems({item, theme}: GitlabItemsProps) {    
+function GitlabItems({item, theme}: GitlabItemsProps) {
     const style = getStyle(theme);
 
     const repoName = item.references?.full || item.project?.path_with_namespace || '';
@@ -192,7 +193,7 @@ function GitlabItems({item, theme}: GitlabItemsProps) {
                 {item.action_name && (
                     <>
                         <div>{item.updated_at && `Updated ${formatTimeSince(item.updated_at)} ago.`}</div>
-                        {item.action_name=='member_access_requested' && <a href={item.author.web_url}>{item.author.name}</a>} {notificationReasons[item.action_name]}
+                        {item.action_name==ActionNameMemberAccessRequested && <a href={item.author.web_url}>{item.author.name}</a>} {notificationReasons[item.action_name]}
                     </>
                 )}
             </div>

--- a/webapp/src/components/sidebar_right/gitlab_items.tsx
+++ b/webapp/src/components/sidebar_right/gitlab_items.tsx
@@ -25,7 +25,7 @@ export const notificationReasons: Record<string | symbol, string> = {
 
 const SUCCESS = 'success';
 const PENDING = 'pending';
-const ActionNameMemberAccessRequested = 'member_access_requested'
+const ActionNameMemberAccessRequested = 'member_access_requested';
 
 function GitlabItems({item, theme}: GitlabItemsProps) {
     const style = getStyle(theme);

--- a/webapp/src/types/gitlab_items.ts
+++ b/webapp/src/types/gitlab_items.ts
@@ -11,6 +11,8 @@ export interface Label {
 
 export interface User {
     username: string;
+    web_url: string;
+    name: string;
 }
 
 export interface References {
@@ -57,6 +59,7 @@ export interface Item {
     num_approvers: number;
     total_reviewers: number;
     reviewers: User[];
+    body: string;
 }
 
 export interface GitlabItemsProps {


### PR DESCRIPTION
Fixes Issue 383 on Gitlab

- Displayed proper title and message for member access requests.
- Updated the "Opened...." message with a more meaningful text. Made it consistent with GitHub plugin UX.

Note: For the second point in the issue a PR is already created: https://github.com/mattermost/mattermost-plugin-gitlab/pull/404

Screenshots:
![image](https://github.com/Brightscout/mattermost-plugin-gitlab/assets/55234496/09c4197c-f5b8-4add-b7ec-c030767e7e9f)
