### PR TITLE
[MM-214] Add user's theme support in link tooltip component

### DIFF
--- a/webapp/src/components/link_tooltip/tooltip.css
+++ b/webapp/src/components/link_tooltip/tooltip.css
@@ -15,7 +15,7 @@
 /* Gitlab Tooltip */
 .gitlab-tooltip .box {
     background-color: var(--center-channel-bg);
-    box-shadow: 0 1px 10px rgba(var(--center-channel-color-rgb), 0.2);
+    box-shadow: 0px 12px 32px 0px rgba(0, 0, 0, 0.12);
     position: relative;
     width: 360px;
     border: 1px solid rgba(var(--center-channel-color-rgb), 0.16);
@@ -30,14 +30,13 @@
 
 /* Header */
 .gitlab-tooltip .header {
-    color: var(--center-channel-color);
+    color: rgba(var(--center-channel-color-rgb), 0.75);;
     font-size: 12px;
-    opacity: 0.7;
 }
 
 .gitlab-tooltip .header a {
     text-decoration: none;
-    color: var(--center-channel-color);
+    color: rgba(var(--center-channel-color-rgb), 0.75);
     display: inline-block;
 }
 
@@ -62,8 +61,7 @@
 }
 
 .mr-number {
-    color: var(--center-channel-color);
-    opacity: 0.7;
+    color: rgba(var(--center-channel-color-rgb), 0.75);
 }
 
 .gitlab-tooltip .tooltip-info h5 {

--- a/webapp/src/components/link_tooltip/tooltip.css
+++ b/webapp/src/components/link_tooltip/tooltip.css
@@ -15,7 +15,7 @@
 /* Gitlab Tooltip */
 .gitlab-tooltip .box {
     background-color: var(--center-channel-bg);
-    box-shadow: 0px 12px 32px 0px rgba(0, 0, 0, 0.12);
+    box-shadow: 0 12px 32px 0 rgba(0, 0, 0, 0.12);
     position: relative;
     width: 360px;
     border: 1px solid rgba(var(--center-channel-color-rgb), 0.16);

--- a/webapp/src/components/link_tooltip/tooltip.css
+++ b/webapp/src/components/link_tooltip/tooltip.css
@@ -14,8 +14,8 @@
 
 /* Gitlab Tooltip */
 .gitlab-tooltip .box {
-    background-color: white;
-    box-shadow: 0 1px 15px rgba(27,31,35,.15);
+    background-color: var(--center-channel-bg);
+    box-shadow: 0 1px 10px rgba(var(--center-channel-color-rgb), 0.2);
     position: relative;
     width: 360px;
 }
@@ -27,13 +27,14 @@
 
 /* Header */
 .gitlab-tooltip .header {
-    color: var(--light-gray);
+    color: var(--center-channel-color);
     font-size: 12px;
+    opacity: 0.7;
 }
 
 .gitlab-tooltip .header a {
     text-decoration: none;
-    color: var(--gray);
+    color: var(--center-channel-color);
     display: inline-block;
 }
 
@@ -52,11 +53,12 @@
 .gitlab-tooltip .tooltip-info > a, .gitlab-tooltip .tooltip-info > a:hover {
     display: block;
     text-decoration: none;
-    color: var(--dark-gray);
+    color: var(--center-channel-color);
 }
 
 .mr-number {
-    color: var(--light-gray);
+    color: var(--center-channel-color);
+    opacity: 0.7;
 }
 
 .gitlab-tooltip .tooltip-info h5 {
@@ -66,6 +68,7 @@
 }
 
 .gitlab-tooltip .tooltip-info .markdown-text {
+    color: var(--center-channel-color);
     -webkit-hyphens: auto;
     -ms-hyphens: auto;
     hyphens: auto;
@@ -78,11 +81,6 @@
 
 .gitlab-tooltip .tooltip-info .markdown-text::-webkit-scrollbar {
     display: none;
-}
-
-.gitlab-tooltip .see-more {
-    font-weight: 600;
-    font-size: 12px;
 }
 
 /* Labels */
@@ -116,9 +114,9 @@
     display: inline-block;
     padding: 0 5px;
     font: .75em/2 SFMono-Regular,Consolas,Liberation Mono,Menlo,monospace;
-    color: var(--blue);
+    color: var(--button-bg);
     white-space: nowrap;
-    background-color: var(--light-blue);
+    background-color: rgba(var(--button-bg-rgb), 0.1);
     border-radius: 3px;
     max-width: 140px;
     text-overflow: ellipsis;


### PR DESCRIPTION
#### Summary
- Add user's theme support in link tooltip component

#### Screenshot
![image](https://github.com/Brightscout/mattermost-plugin-gitlab/assets/55234496/0292b152-8894-4d8a-8b77-0ba0c9809d8a)
![image](https://github.com/Brightscout/mattermost-plugin-gitlab/assets/55234496/d029b548-e26c-420e-9daf-ce5734862aa6)
#### What to test?
- Link tooltip component is working properly according to the different themes.

#### Ticket Link:
Fixes: https://community.mattermost.com/core/pl/97pq3s9u6bnd7ghxx8qpu1x7oc